### PR TITLE
simple fix to dump_rifgen_text

### DIFF
--- a/apps/rosetta/riflib/RifFactory.cc
+++ b/apps/rosetta/riflib/RifFactory.cc
@@ -547,7 +547,7 @@ public:
             }
 
             int irot = rotscores.rotamer(i_rs);
-            char oneletter = rot_index_p->oneletter(irot);
+            std::string oneletter = rot_index_p->oneletter(irot);
             float score = rotscores.score(i_rs);
 
             std::vector<int> sats;


### PR DESCRIPTION
broke the function by changing the oneletter in RotamerIndex. This fix the error and get rid of the compiler error.  