### PR TITLE
Adding dumping hotspots and rotamer boltzmann tools

### DIFF
--- a/apps/rosetta/rif_dock_test.cc
+++ b/apps/rosetta/rif_dock_test.cc
@@ -804,6 +804,14 @@ int main(int argc, char *argv[]) {
 	        }
 
 		}
+
+		if ( opt.dump_rifgen_for_sat.size() > 0 ) {
+			rif_ptrs.back()->dump_rotamers_for_sats( opt.dump_rifgen_for_sat, opt.dump_rifgen_for_sat_models, rot_index_p );
+		}
+
+		if ( opt.dump_best_rifgen_rots > 0 ) {
+			rif_ptrs.back()->dump_the_best_rifres( opt.dump_best_rifgen_rots, opt.dump_best_rifgen_rmsd, rot_index_p );
+		}
 	}
 
 
@@ -884,6 +892,8 @@ int main(int argc, char *argv[]) {
             	rso_config.hydrophobic_manager = hydrophobic_manager;
             	rso_config.require_hydrophobic_residue_contacts = opt.require_hydrophobic_residue_contacts;
             	rso_config.hydrophobic_ddg_cut = opt.hydrophobic_ddg_cut;
+
+            	rso_config.ignore_rifres_if_worse_than = opt.ignore_rifres_if_worse_than;
 
 
             if ( opt.require_satisfaction > 0 && rif_ptrs.back()->has_sat_data_slots() ) {

--- a/apps/rosetta/riflib/RifBase.hh
+++ b/apps/rosetta/riflib/RifBase.hh
@@ -104,6 +104,11 @@ struct RifBase
     // To randomly dump rif residues defined by res names, and "*" means all 20 amino acids.
     virtual bool random_dump_rotamers( std::vector< std::string > res_names_dump, std::string const file_name, float dump_fraction, shared_ptr<RotamerIndex> rot_index_p ) const = 0;
 
+
+    virtual bool dump_the_best_rifres( size_t num_to_dump, float rmsd_resl, shared_ptr<RotamerIndex> rot_index_p ) const = 0;
+
+    virtual bool dump_rotamers_for_sats( std::vector< size_t > const & sat, size_t number_to_dump, shared_ptr<RotamerIndex> rot_index_p ) const = 0;
+
     virtual bool dump_rotamers_near_res( core::conformation::Residue const & res, std::string const & file_name, 
                                            float dump_dist, float dump_frac, shared_ptr<RotamerIndex> rot_index_p, bool last_atom_only ) const = 0;
 

--- a/apps/rosetta/riflib/RifFactory.hh
+++ b/apps/rosetta/riflib/RifFactory.hh
@@ -133,6 +133,7 @@ struct RifSceneObjectiveConfig
     shared_ptr<HydrophobicManager> hydrophobic_manager;
     float sasa_threshold;
     float sasa_multiplier;
+    float ignore_rifres_if_worse_than;
 
 };
 

--- a/apps/rosetta/riflib/rifdock_tasks/OutputResultsTasks.cc
+++ b/apps/rosetta/riflib/rifdock_tasks/OutputResultsTasks.cc
@@ -297,6 +297,13 @@ dump_rif_result_(
                         }
                     }
 
+                    float rotboltz = 0;
+                    if ( sdc->rotboltz_data_p ) {
+                        if ( sdc->rotboltz_data_p->at(ires).size() > 0 ) {
+                            rotboltz = sdc->rotboltz_data_p->at(ires)[irot];
+                        }
+                    }
+
                     if ( ! quiet ) {
 
                         std::cout << ( rot_was_placed ? "*" : " " );
@@ -305,6 +312,9 @@ dump_rif_result_(
                         std::cout << " score:" << F(7, 2, sc);
                         std::cout << " irot:" << I(3, irot);
                         std::cout << " 1-body:" << F(7, 2, onebody );
+                        if ( sdc->rotboltz_data_p ) {
+                            std::cout << " rotboltz:" << F(7, 2, rotboltz );
+                        }
                         std::cout << " rif score:" << F(7, 2, p.first);
                         std::cout << " rif rescore:" << F(7, 2, rescore);
                         std::cout << " sats:" << I(3, sat1_sat2.first) << " " << I(3, sat1_sat2.second) << " ";

--- a/apps/rosetta/riflib/rifdock_tasks/RosettaScoreAndMinTasks.cc
+++ b/apps/rosetta/riflib/rifdock_tasks/RosettaScoreAndMinTasks.cc
@@ -338,6 +338,7 @@ rosetta_score_inner(
             xform_pose( pose_to_min, eigen2xyz(xalignout*xposition1) ,                      1 ,    scaffold_size );
 
             // place the rotamers
+            float rotamer_penalty = 0;
             core::chemical::ResidueTypeSetCAP rts = core::chemical::ChemicalManager::get_instance()->residue_type_set("fa_standard");
             std::vector<bool> is_rif_res(pose_to_min.size(),false);
             for( int ipr = 0; ipr < packed_results[imin].numrots(); ++ipr ){
@@ -348,6 +349,9 @@ rosetta_score_inner(
                 is_rif_res[ires] = true;
                 for( int ichi = 0; ichi < rot_index.nchi(irot); ++ichi ){
                     pose_to_min.set_chi( ichi+1, ires+1, rot_index.chi( irot, ichi ) );
+                }
+                if ( sdc->rotboltz_data_p ) {
+                    rotamer_penalty += sdc->rotboltz_data_p->at( ires )[irot];
                 }
             }
 
@@ -457,6 +461,7 @@ rosetta_score_inner(
                 packed_results[imin].score = pose_to_min.energies().total_energy();
             } else {
                 double rosetta_score = 0.0;
+                rosetta_score += rotamer_penalty;
                 auto const & weights = pose_to_min.energies().weights();
                 if( !rdd.opt.rosetta_score_ddg_only ){
                     for( int ir = 1; ir <= scaffold_size; ++ir ){

--- a/apps/rosetta/riflib/rotamer_energy_tables.hh
+++ b/apps/rosetta/riflib/rotamer_energy_tables.hh
@@ -28,7 +28,8 @@ void get_onebody_rotamer_energies(
 	std::string const & cachefile,
 	bool replace_with_ala = true,
 	float favorable_1be_multiplier = 1,
-	float favorable_1be_cutoff = 0
+	float favorable_1be_cutoff = 0,
+	std::shared_ptr< std::vector< std::vector<float> > > extra_scores_p = nullptr
 );
 
 void

--- a/apps/rosetta/riflib/scaffold/ExtraScaffoldData.hh
+++ b/apps/rosetta/riflib/scaffold/ExtraScaffoldData.hh
@@ -1,0 +1,42 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+//
+// (c) Copyright Rosetta Commons Member Institutions.
+// (c) This file is part of the Rosetta software suite and is made available under license.
+// (c) The Rosetta software is developed by the contributing members of the Rosetta Commons.
+// (c) For more information, see http://www.rosettacommons.org. Questions about this can be
+// (c) addressed to University of Washington UW TechTransfer, email: license@u.washington.edu.
+
+
+#ifndef INCLUDED_riflib_scaffold_ExtraScaffoldData_hh
+#define INCLUDED_riflib_scaffold_ExtraScaffoldData_hh
+
+
+#include <scheme/types.hh>
+
+#include <riflib/HSearchConstraints.hh>
+
+#include <vector>
+
+
+namespace devel {
+namespace scheme {
+
+struct ExtraScaffoldData {
+    ExtraScaffoldData () :
+        csts(),
+        force_scaffold_center( Eigen::Vector3f {std::numeric_limits<double>::quiet_NaN(), 0, 0} ),
+        rotboltz_data_p( nullptr )
+    {}
+
+
+    std::vector<CstBaseOP> csts;
+    Eigen::Vector3f force_scaffold_center;
+    std::shared_ptr< std::vector< std::vector<float> > > rotboltz_data_p;
+};
+
+
+}
+}
+
+#endif

--- a/apps/rosetta/riflib/scaffold/MorphingScaffoldProvider.cc
+++ b/apps/rosetta/riflib/scaffold/MorphingScaffoldProvider.cc
@@ -47,10 +47,11 @@ MorphingScaffoldProvider::MorphingScaffoldProvider(
     core::pose::Pose scaffold;
     utility::vector1<core::Size> scaffold_res;
     EigenXform scaffold_perturb;
-    std::vector<CstBaseOP> csts;
     MorphRules morph_rules;
+    ExtraScaffoldData extra_data;
 
-    get_info_for_iscaff( iscaff, opt, scafftag, scaffold, scaffold_res, scaffold_perturb, csts, morph_rules);
+
+    get_info_for_iscaff( iscaff, opt, scafftag, scaffold, scaffold_res, scaffold_perturb, morph_rules, extra_data, rot_index_p);
 
     ScaffoldDataCacheOP temp_data_cache_ = make_shared<ScaffoldDataCache>(
         scaffold,
@@ -59,7 +60,7 @@ MorphingScaffoldProvider::MorphingScaffoldProvider(
         scaffold_perturb,
         rot_index_p,
         opt,
-        csts);
+        extra_data);
 
     ParametricSceneConformationCOP conformation = make_conformation_from_data_cache(temp_data_cache_, false);
 
@@ -86,11 +87,11 @@ MorphingScaffoldProvider::test_make_children(TreeIndex ti) {
     core::pose::Pose _scaffold;
     utility::vector1<core::Size> scaffold_res;
     EigenXform scaffold_perturb;
-    std::vector<CstBaseOP> csts;
     MorphRules morph_rules;
+    ExtraScaffoldData extra_data;
 
 
-    get_info_for_iscaff( 0, opt, scafftag, _scaffold, scaffold_res, scaffold_perturb, csts, morph_rules);
+    get_info_for_iscaff( 0, opt, scafftag, _scaffold, scaffold_res, scaffold_perturb, morph_rules, extra_data, rot_index_p);
 
 
 
@@ -159,6 +160,8 @@ MorphingScaffoldProvider::test_make_children(TreeIndex ti) {
             for ( core::pose::PoseOP pose : poses ) {
                 count++;
 
+                extra_data.force_scaffold_center = data_cache->scaffold_center;
+
                 ScaffoldDataCacheOP temp_data_cache_ = make_shared<ScaffoldDataCache>(
                     *pose,
                     scaffold_res,
@@ -166,8 +169,8 @@ MorphingScaffoldProvider::test_make_children(TreeIndex ti) {
                     scaffold_perturb,
                     rot_index_p,
                     opt,
-                    csts,
-                    data_cache->scaffold_center);
+                    extra_data
+                    );
 
 
                 if ( opt.use_parent_body_energies ) {
@@ -244,6 +247,8 @@ MorphingScaffoldProvider::test_make_children(TreeIndex ti) {
 
             apply_xform_to_pose( *pose, archetype_to_input );
 
+            extra_data.force_scaffold_center = data_cache->scaffold_center;
+
             ScaffoldDataCacheOP temp_data_cache_ = make_shared<ScaffoldDataCache>(
                 *pose,
                 scaffold_res,
@@ -251,8 +256,8 @@ MorphingScaffoldProvider::test_make_children(TreeIndex ti) {
                 scaffold_perturb,
                 rot_index_p,
                 opt,
-                csts,
-                data_cache->scaffold_center);
+                extra_data
+                );
 
 
             if ( opt.use_parent_body_energies ) {

--- a/apps/rosetta/riflib/scaffold/NineAManager.hh
+++ b/apps/rosetta/riflib/scaffold/NineAManager.hh
@@ -282,7 +282,7 @@ struct NineAManager : public utility::pointer::ReferenceCount {
         std::string scafftag = pose_p->pdb_info()->name();
         utility::vector1<core::Size> scaffold_res;
         EigenXform scaffold_perturb = EigenXform::Identity();
-        std::vector<CstBaseOP> csts;
+        ExtraScaffoldData extra_data;
 
         get_default_scaffold_res(*pose_p, scaffold_res);
 
@@ -293,7 +293,7 @@ struct NineAManager : public utility::pointer::ReferenceCount {
             scaffold_perturb,
             rot_index_p,
             opt,
-            csts);
+            extra_data);
 
         nine.conformation = make_conformation_from_data_cache(temp_data_cache, false);
 

--- a/apps/rosetta/riflib/scaffold/SingleFileScaffoldProvider.cc
+++ b/apps/rosetta/riflib/scaffold/SingleFileScaffoldProvider.cc
@@ -45,10 +45,10 @@ SingleFileScaffoldProvider::SingleFileScaffoldProvider(
     core::pose::Pose scaffold;
     utility::vector1<core::Size> scaffold_res;
     EigenXform scaffold_perturb;
-    std::vector<CstBaseOP> csts;
     MorphRules morph_rules;
+    ExtraScaffoldData extra_data;
 
-    get_info_for_iscaff( iscaff, opt, scafftag, scaffold, scaffold_res, scaffold_perturb, csts, morph_rules);
+    get_info_for_iscaff( iscaff, opt, scafftag, scaffold, scaffold_res, scaffold_perturb, morph_rules, extra_data, rot_index_p);
 
     ScaffoldDataCacheOP temp_data_cache = make_shared<ScaffoldDataCache>(
         scaffold,
@@ -57,7 +57,7 @@ SingleFileScaffoldProvider::SingleFileScaffoldProvider(
         scaffold_perturb,
         rot_index_p,
         opt,
-        csts);
+        extra_data);
 
     conformation_ = make_conformation_from_data_cache(temp_data_cache, false);
 

--- a/apps/rosetta/riflib/scaffold/util.hh
+++ b/apps/rosetta/riflib/scaffold/util.hh
@@ -19,6 +19,7 @@
 #include <protocols/minimization_packing/TaskAwareMinMover.hh>
 #include <protocols/simple_moves/MutateResidue.hh>
 #include <core/scoring/ScoreFunction.hh>
+#include <riflib/scaffold/ExtraScaffoldData.hh>
 
 #include <core/pose/Pose.hh>
 #include <core/scoring/Energies.hh>
@@ -47,8 +48,9 @@ get_info_for_iscaff(
     core::pose::Pose & scaffold,
     utility::vector1<core::Size> & scaffold_res,
     EigenXform & scaffold_perturb,
-    std::vector<CstBaseOP> & csts,
-    MorphRules & morph_rules
+    MorphRules & morph_rules,
+    ExtraScaffoldData & extra_data,
+    shared_ptr< RotamerIndex > rot_index_p_in
     );
 
 // historically, non_fa was used during HSearch and fa was used during hack pack
@@ -106,6 +108,14 @@ std::string
 pdb_name( std::string const & fname );
 
 
+
+std::shared_ptr< std::vector< std::vector<float> > >
+load_rotboltz_data(
+    std::string const & fname,
+    size_t num_res,
+    size_t num_rots,
+    bool ignore_missing_rots
+);
 
 }}
 

--- a/schemelib/scheme/io/dump_pdb_atom.hh
+++ b/schemelib/scheme/io/dump_pdb_atom.hh
@@ -35,11 +35,11 @@ inline void dump_pdb_atom(
 	if( aname.size() == 2 ) aname = aname+" ";
 	snprintf(buf,128,"%s%5i %4s %3s %c%4i    %8.3f%8.3f%8.3f%6.2f%6.2f %11s\n",
 		a.ishet ? "HETATM":"ATOM  ",
-		a.atomnum,
+		a.atomnum % 100000,
 		aname.c_str(),
 		a.resname.c_str(),
 		a.chain,
-		a.resnum,
+		a.resnum % 10000,
 		x,y,z,
 		a.occ,
 		a.bfac,


### PR DESCRIPTION
Awesome new debugging flags:

Dump hotspots/bidentates:
-dump_rifgen_for_sat <sat number or sat numbers>
-dump_rifgen_for_sat_models 1000 # or however many you want

Dump the best rotamers from rifgen:
-dump_best_rifgen_rots 1000 # or however many you want
-dump_best_rifgen_rmsd 3 # default is 3