### PR TITLE
Add HBOND options to CATIONPI, PIPI, and APOLAR requirements

### DIFF
--- a/apps/rosetta/rif_dock_test.hh
+++ b/apps/rosetta/rif_dock_test.hh
@@ -371,7 +371,7 @@ OPT_1GRP_KEY(     StringVector , rif_dock, scaffolds )
             NEW_OPT(  rif_dock::dump_rifgen_near_pdb_last_atom, "Use only the last atom to decide if rotamers are close", false );
 			NEW_OPT(  rif_dock::dump_rifgen_text, "Dump the rifgen tables within dump_rifgen_near_pdb_dist", false );
             NEW_OPT(  rif_dock::dump_rifgen_for_sat, "Dump a rotamers near a specific sat or multiple sats", utility::vector1<size_t>());
-            NEW_OPT(  rif_dock::dump_rifgen_for_sat_models, "Number of rotamers to dump for dump_rifgen_for_sat", 1000);
+            NEW_OPT(  rif_dock::dump_rifgen_for_sat_models, "Number of rotamers to dump for dump_rifgen_for_sat", 200);
             NEW_OPT(  rif_dock::dump_rifgen_for_sat_name3, "Only dump rotamers with this name3", "");
             NEW_OPT(  rif_dock::dump_best_rifgen_rots, "Dump the best rotamer from the rifgen. This is how many", 0 );
             NEW_OPT(  rif_dock::dump_best_rifgen_rmsd, "The rmsd of the last atom for each aa type used in clustering", 3 );

--- a/apps/rosetta/riflib/ScoreRotamerVsTarget.hh
+++ b/apps/rosetta/riflib/ScoreRotamerVsTarget.hh
@@ -101,6 +101,11 @@ struct ScoreRotamerVsTarget {
     ::scheme::shared_ptr< RotamerIndex const > rot_index_p_ = nullptr;
     std::vector<VoxelArrayPtr> target_field_by_atype_;
     std::vector< HBondRay > target_donors_, target_acceptors_;
+
+    // Ok, the names shouldn't be here, but it's convenient
+    std::vector<std::pair<int, std::string> > target_donor_names;
+    std::vector<std::pair<int, std::string> > target_acceptor_names;
+
     float hbond_weight_ = 2.0;
     float upweight_iface_ = 1.0;
     float upweight_multi_hbond_ = 0.0;

--- a/apps/rosetta/riflib/rif/RifGenerator.hh
+++ b/apps/rosetta/riflib/rif/RifGenerator.hh
@@ -13,21 +13,28 @@
 #define INCLUDED_riflib_rif_RifGenerator_hh
 
 #include <riflib/types.hh>
-#include <riflib/RotamerGenerator.hh>
+// #include <riflib/RotamerGenerator.hh>
 #include <riflib/RifBase.hh>
 #include <core/pose/Pose.hh>
 #include <utility/vector1.hh>
+#include <riflib/rifdock_typedefs.hh>
 #include <string>
 
 #ifdef USEGRIDSCORE
 	#include <protocols/ligand_docking/GALigandDock/GridScorer.hh>
 #endif
 
-namespace scheme {
-namespace chemical {
-	struct RotamerIndexSpec;
-}
-}
+// namespace devel {
+// namespace scheme {
+// 	struct ScoreRotamerVsTarget;
+// }
+// }
+
+// namespace scheme {
+// namespace chemical {
+// 	struct RotamerIndexSpec;
+// }
+// }
 
 namespace devel {
 namespace scheme {
@@ -65,8 +72,9 @@ struct RifGenParams {
 	HBRayOpts                      hbopt;
 #ifdef USEGRIDSCORE
 	shared_ptr<protocols::ligand_docking::ga_ligand_dock::GridScorer> grid_scorer;
-	bool                           soft_grid_energies;
 #endif
+	// the only reason this is a pointer is to avoid including a bunch of stuff this high up
+	shared_ptr<RifScoreRotamerVsTarget> rot_tgt_scorer;
 };
 typedef shared_ptr<RifGenParams> RifGenParamsP;
 

--- a/apps/rosetta/riflib/rif/RifGeneratorApoHSearch.hh
+++ b/apps/rosetta/riflib/rif/RifGeneratorApoHSearch.hh
@@ -25,6 +25,7 @@ struct RifGeneratorApoHSearchOpts {
 	bool downweight_hydrophobics = false;
 	float beam_size_M = 10000.0;
 	float dump_fraction = 0.0;
+	bool only_place_requirement_res = false;
 };
 
 struct RifGeneratorApoHSearch : public RifGenerator {

--- a/apps/rosetta/riflib/rif/RifGeneratorSimpleHbonds.cc
+++ b/apps/rosetta/riflib/rif/RifGeneratorSimpleHbonds.cc
@@ -320,8 +320,6 @@ RifGeneratorSimpleHbonds::prepare_hbgeoms(
         bool const use_hbond_definition = !( hbond_definitions.empty() );
         std::vector< int > use_hbond_definition_rays;
         std::vector< std::vector< std::string > > allowed_rotamers_rays;
-        std::vector<std::pair<int, std::string> > target_donor_names;
-        std::vector<std::pair<int, std::string> > target_acceptor_names;
         std::vector<std::pair<int, std::string> > target_bonder_names;
         // the bidentate hydrogen bond definition stuff
         std::vector< BidentateDefinition > bidentate_definitions = get_bidentate_definitions( tuning_file );
@@ -398,16 +396,10 @@ RifGeneratorSimpleHbonds::prepare_hbgeoms(
 				}
 			}
 		}
-		std::vector< ::scheme::chemical::HBondRay > target_donors, target_acceptors;
-		for( auto ir : target_res ){
-            ::devel::scheme::get_donor_rays   ( target, ir, params->hbopt, target_donors, target_donor_names );
-            ::devel::scheme::get_acceptor_rays( target, ir, params->hbopt, target_acceptors, target_acceptor_names );
-		}
         // this is to fill the allowed_rotamers_rays
         {
-            
-            target_bonder_names = target_donor_names;
-            for ( auto const & x : target_acceptor_names ) target_bonder_names.push_back( x );
+            target_bonder_names = params->rot_tgt_scorer->target_donor_names;
+            for ( auto const & x : params->rot_tgt_scorer->target_acceptor_names ) target_bonder_names.push_back( x );
             
             // remove the space in the atoms
             for ( auto  & x : target_bonder_names )
@@ -512,22 +504,9 @@ RifGeneratorSimpleHbonds::prepare_hbgeoms(
              }
              */
         }
-        {
-			// these get used now. Don't change the names!!!
-			
-			utility::io::ozstream donout(params->output_prefix+"donors.pdb.gz");
-			::devel::scheme::dump_hbond_rays( donout, target_donors, true );
-			donout.close();
-			
-			utility::io::ozstream accout(params->output_prefix+"acceptors.pdb.gz");
-			::devel::scheme::dump_hbond_rays( accout, target_acceptors, false );
-			accout.close();
-			
-			// utility_exit_with_message("debug hbonds");
-		}
-		std::cout << "target_donors.size() " << target_donors.size() << " target_acceptors.size() " << target_acceptors.size() << std::endl;
+
 		int n_sat_groups = 0;
-		if( accumulator->rif()->has_sat_data_slots() ) n_sat_groups = target_donors.size() + target_acceptors.size();
+		if( accumulator->rif()->has_sat_data_slots() ) n_sat_groups = params->rot_tgt_scorer->target_donors_.size() + params->rot_tgt_scorer->target_acceptors_.size();
 		std::vector<utility::io::ozstream*> rif_hbond_vis_out_satgroups(n_sat_groups,nullptr);
 		std::vector<std::vector<utility::io::ozstream*>> rif_hbond_vis_out_double_satgroups(
 		                                                     n_sat_groups, std::vector<utility::io::ozstream*>(n_sat_groups,nullptr));
@@ -536,30 +515,6 @@ RifGeneratorSimpleHbonds::prepare_hbgeoms(
 
 	// target.dump_pdb("test.pdb");
 	// utility_exit_with_message("DEBUG EXTRA ACCEPTORS!!!");
-		devel::scheme::ScoreRotamerVsTarget<
-				VoxelArrayPtr, ::scheme::chemical::HBondRay, ::devel::scheme::RotamerIndex
-			> rot_tgt_scorer;
-		{
-			rot_tgt_scorer.rot_index_p_ = rot_index_p;
-			rot_tgt_scorer.target_field_by_atype_ = field_by_atype;
-			rot_tgt_scorer.target_donors_ = target_donors;
-			rot_tgt_scorer.target_acceptors_ = target_acceptors;
-			rot_tgt_scorer.hbond_weight_ = opts.hbond_weight;
-			rot_tgt_scorer.upweight_multi_hbond_ = opts.upweight_multi_hbond || opts.dump_bindentate_hbonds;
-			rot_tgt_scorer.upweight_iface_ = 1.0;
-			rot_tgt_scorer.min_hb_quality_for_satisfaction_ = opts.min_hb_quality_for_satisfaction;
-            rot_tgt_scorer.long_hbond_fudge_distance_ = opts.long_hbond_fudge_distance;
-#ifdef USEGRIDSCORE
-			rot_tgt_scorer.grid_scorer_ = params->grid_scorer;
-			rot_tgt_scorer.soft_grid_energies_ = params->soft_grid_energies;
-#endif
-            shared_ptr<DonorAcceptorCache> target_donor_cache, target_acceptor_cache;
-            prepare_donor_acceptor_cache( target_donors, target_acceptors, rot_tgt_scorer, target_donor_cache, target_acceptor_cache );
-
-            rot_tgt_scorer.target_donor_cache_ = target_donor_cache;
-            rot_tgt_scorer.target_acceptor_cache_ = target_acceptor_cache;
-
-		}
 
 		// int npairs = donresn.size()*accresn_user.size()  +  accresn.size()*donresn_user.size() ;
 
@@ -972,7 +927,7 @@ RifGeneratorSimpleHbonds::prepare_hbgeoms(
 						int sat1=-1, sat2=-1;
 						int hbcount=0;
 						bool want_sats = n_sat_groups > 0;
-						float positioned_rotamer_score = rot_tgt_scorer.score_rotamer_v_target_sat( irot, bbactor.position_, sat1, sat2, 
+						float positioned_rotamer_score = params->rot_tgt_scorer->score_rotamer_v_target_sat( irot, bbactor.position_, sat1, sat2, 
 																									want_sats, hbcount, 10.0, 0 );
 						if( positioned_rotamer_score > opts.score_threshold ) continue;
                         

--- a/apps/rosetta/riflib/rif/RifGeneratorSimpleHbonds.hh
+++ b/apps/rosetta/riflib/rif/RifGeneratorSimpleHbonds.hh
@@ -28,10 +28,6 @@ struct RifGeneratorSimpleHbondsOpts {
 	float hbond_cart_sample_hack_resl = 0.25;
 	float score_threshold = 0.0;
 	float dump_fraction = 0.0;
-	float hbond_weight = 2.0;
-	float upweight_multi_hbond = 0;
-	float min_hb_quality_for_satisfaction = -0.6;
-	float long_hbond_fudge_distance = 0.0;
 	bool debug = false;
 	bool dump_bindentate_hbonds = false;
 	bool report_aa_count = false;

--- a/apps/rosetta/riflib/rif/RifGeneratorUserHotspots.hh
+++ b/apps/rosetta/riflib/rif/RifGeneratorUserHotspots.hh
@@ -26,10 +26,6 @@ struct RifGeneratorUserHotspotsOpts {
 	float hotspot_sample_angle_bound = 30.0;
     float hotspot_score_thresh = -0.5;
     int   hotspot_nsamples = 10000;
-	float hbond_weight = 2.0;
-	float upweight_multi_hbond = 0.0;
-	float min_hb_quality_for_satisfaction = -0.6;
-    float long_hbond_fudge_distance = 0.0;
     int  dump_hotspot_samples = 0;
     bool test_hotspot_redundancy = false;
 	float hotspot_score_bonus = 0.;

--- a/apps/rosetta/riflib/rif/requirements_util.cc
+++ b/apps/rosetta/riflib/rif/requirements_util.cc
@@ -15,7 +15,6 @@
 #include <utility/io/izstream.hh>
 #include <utility/io/ozstream.hh>
 
-#include <utility/string_util.hh>
 
 namespace devel {
     namespace scheme {
@@ -336,6 +335,7 @@ namespace devel {
                         
                         utility::vector1<std::string> splt = utility::quoted_split( s );
                         if ( splt.size() >=2 && splt[2] == "APOLAR" ) {
+                            splt = parse_apo_hbond( splt, 3, req_temp );
                             runtime_assert_msg( utility::string2int( splt[1] ) >=0, "The requirement number must be a positive integer!" );
                             req_temp.req_num = utility::string2int( splt[1] );
                             for (int ii = 3; ii <= splt.size(); ++ii) {
@@ -360,6 +360,7 @@ namespace devel {
                             req_temp.req_num = -1;
                             req_temp.allowed_rot_names.clear();
                             req_temp.terms.clear();
+                            clear_apo_hbond( req_temp );
                             found_one = false;
                         } else {
                             utility_exit_with_message("something is wrong with the APOLAR requirement definition!" );
@@ -405,6 +406,7 @@ namespace devel {
                         
                         utility::vector1<std::string> splt = utility::quoted_split( s );
                         if ( splt.size() >=2 && splt[2] == "PIPISTACKING" ) {
+                            splt = parse_apo_hbond( splt, 3, req_temp );
                             runtime_assert_msg( utility::string2int( splt[1] ) >=0, "The requirement number must be a positive integer!" );
                             req_temp.req_num = utility::string2int( splt[1] );
                             if ( splt.size() == 2 ) {
@@ -433,6 +435,7 @@ namespace devel {
                             req_temp.req_num = -1;
                             req_temp.allowed_rot_names.clear();
                             req_temp.terms.clear();
+                            clear_apo_hbond( req_temp );
                             found_one = false;
                         } else {
                             utility_exit_with_message("something is wrong with the APOLAR requirement definition!" );
@@ -477,6 +480,7 @@ namespace devel {
                         //std::cout << req_temp.req_num << std::endl;
                         
                         if ( splt.size() >=2 && splt[2] == "CATIONPI" ) {
+                            splt = parse_apo_hbond( splt, 3, req_temp );
                             runtime_assert_msg( splt.size() >= 3, "something is wrong with the CATIONPI requirement definition, talk with longxing about this. You can specify the allow residues to form a cationpi, such as TRP, PHE, HIS!" );
                             runtime_assert_msg( utility::string2int( splt[1] ) >=0, "The requirement number must be a positive integer!" );
                             req_temp.req_num = utility::string2int(splt[1]);

--- a/apps/rosetta/riflib/rif/requirements_util.hh
+++ b/apps/rosetta/riflib/rif/requirements_util.hh
@@ -10,10 +10,11 @@
 
 
 #ifndef INCLUDED_riflib_rif_requirements_util_hh
-#define INCLUDED_riflib_rif_requirements_util__hh
+#define INCLUDED_riflib_rif_requirements_util_hh
 
 #include <string>
 #include <vector>
+#include <utility/string_util.hh>
 
 // TODO:: change this tuning file manager to a factory ..... Singleton ?
 
@@ -73,6 +74,7 @@ namespace devel {
                 int req_num = -1;
                 std::vector<std::string> allowed_rot_names;
                 std::vector<ApoReqTerm> terms;
+                HbondRequirement apo_hbond;
             };
             
             struct PiPiStackingTerm {
@@ -83,12 +85,14 @@ namespace devel {
                 int req_num = -1;
                 std::vector<std::string> allowed_rot_names;
                 std::vector<PiPiStackingTerm> terms;
+                HbondRequirement apo_hbond;
             };
             
             struct CationPiRequirement {
                 int req_num = -1;
                 int res_num = -1;
                 std::vector<std::string> allowed_rot_names;
+                HbondRequirement apo_hbond;
             };
             
             std::vector < DonorDefinition > get_donor_definitions( std::string tuning_file );
@@ -102,6 +106,37 @@ namespace devel {
             std::vector< PiPiStackingRequirement > get_pipi_stacking_requirement_definitions( std::string tuning_file );
             std::vector< CationPiRequirement > get_cationpi_requirement_definitions( std::string tuning_file );
             bool check_requirement_definition_exists( std::string tuning_file );
+
+            template< class Requirement >
+            void
+            clear_apo_hbond( Requirement & req ) {
+                req.apo_hbond.atom_name = "";
+                req.apo_hbond.res_num = -1;
+            }
+
+            template< class Requirement >
+            utility::vector1<std::string>
+            parse_apo_hbond( utility::vector1<std::string> const & split, size_t start, Requirement & req ) {
+                size_t hbond_start = 0;
+                for ( size_t i = start; i <= split.size(); i++ ) {
+                    if ( split[i] == "HBOND" ) {
+                        hbond_start = i;
+                        break;
+                    }
+                }
+                if ( hbond_start == 0 ) return split;
+
+                if ( hbond_start + 2 > split.size() ) {
+                    utility_exit_with_message("Bad apo-hbond definition");
+                }
+                req.apo_hbond.atom_name = split[hbond_start+1];
+                req.apo_hbond.res_num = utility::string2int(split[hbond_start+2]);
+
+                utility::vector1<std::string> new_split;
+                for ( size_t i = 1; i < hbond_start; i++ ) new_split.push_back(split[i]);
+                return new_split;
+            }
+
         }
     }
 }

--- a/apps/rosetta/riflib/rotamer_energy_tables.cc
+++ b/apps/rosetta/riflib/rotamer_energy_tables.cc
@@ -437,11 +437,18 @@ void get_per_rotamer_rf_tables_one(
 		lb = lb.min(a.position());
 		ub = ub.max(a.position());
 	}
+
+	std::string chi_string = "";
+	for ( int i = 0; i < rot_index.nchi(irot); i++ ) {
+		if ( i > 0 ) chi_string += "_";
+		chi_string += boost::str( boost::format("%.2f")%rot_index.chi(irot, i) );
+	}
 	// cout << "rosetta_field lb " << lb << endl;
 	// cout << "rosetta_field ub " << ub << endl;
 
 	std::string cachefile = opts.data_dir
-	                 +"/__rotamer_"+str(irot,3)+resname
+	                 +"/__rotamer_"+resname
+	                 +"__chi"       +chi_string
 	                 +"__resl"      +boost::lexical_cast<std::string>(opts.field_resl)
 	                 +"__spread"    +boost::lexical_cast<std::string>(opts.field_spread)
 		             +"__oversamp"  +boost::lexical_cast<std::string>(opts.oversample);

--- a/apps/rosetta/riflib/util.cc
+++ b/apps/rosetta/riflib/util.cc
@@ -400,7 +400,8 @@ get_rif_atype_map()
 	atypemap[ ats->atom_type_index("Nhis") ] =  8;
 	atypemap[ ats->atom_type_index("NH2O") ] =  9;
 	atypemap[ ats->atom_type_index("Nlys") ] = 10;
-	atypemap[ ats->atom_type_index("Narg") ] = 11;
+	// atypemap[ ats->atom_type_index("Narg") ] = 11;
+	atypemap[ ats->atom_type_index("Narg") ] = 6; // hack hack hack hack
 	atypemap[ ats->atom_type_index("Npro") ] = 12;
 	atypemap[ ats->atom_type_index("OH"  ) ] = 13;
 	atypemap[ ats->atom_type_index("ONH2") ] = 14;

--- a/apps/rosetta/riflib/util.cc
+++ b/apps/rosetta/riflib/util.cc
@@ -400,8 +400,8 @@ get_rif_atype_map()
 	atypemap[ ats->atom_type_index("Nhis") ] =  8;
 	atypemap[ ats->atom_type_index("NH2O") ] =  9;
 	atypemap[ ats->atom_type_index("Nlys") ] = 10;
-	// atypemap[ ats->atom_type_index("Narg") ] = 11;
-	atypemap[ ats->atom_type_index("Narg") ] = 6; // hack hack hack hack
+	atypemap[ ats->atom_type_index("Narg") ] = 11;
+	//atypemap[ ats->atom_type_index("Narg") ] = 6; // hack hack hack hack
 	atypemap[ ats->atom_type_index("Npro") ] = 12;
 	atypemap[ ats->atom_type_index("OH"  ) ] = 13;
 	atypemap[ ats->atom_type_index("ONH2") ] = 14;

--- a/schemelib/scheme/chemical/RotamerIndex.hh
+++ b/schemelib/scheme/chemical/RotamerIndex.hh
@@ -412,7 +412,13 @@ struct RotamerIndex {
 	size_t size() const { return rotamers_.size(); }
 	size_t n_primary_rotamers() const { return n_primary_rotamers_; }
 	std::string resname(size_t i) const { return rotamers_.at(i).resname_; }
-	std::string oneletter(size_t i) const { return oneletter_map_.at(rotamers_.at(i).resname_); }
+	std::string oneletter(size_t i) const { 
+		if ( oneletter_map_.find(rotamers_.at(i).resname_) == oneletter_map_.end() ) {
+			return rotamers_.at(i).resname_;
+		} else {
+			return oneletter_map_.at(rotamers_.at(i).resname_);
+		}
+	}
 	size_t natoms( size_t i ) const { return rotamers_.at(i).atoms_.size(); }
 	size_t nheavyatoms( size_t i ) const { return rotamers_.at(i).nheavyatoms; }
 	size_t nchi( size_t i ) const { return rotamers_.at(i).chi_.size(); }


### PR DESCRIPTION
I finally unified the ScoreRotamerVsTarget on the rifgen side which cleans up a lot of things.