### PR TITLE
Added support for writing outputs as "compressed" silent files

### DIFF
--- a/apps/rosetta/rif_dock_test.hh
+++ b/apps/rosetta/rif_dock_test.hh
@@ -53,6 +53,7 @@ OPT_1GRP_KEY(     StringVector , rif_dock, scaffolds )
 	OPT_1GRP_KEY(  Boolean     , rif_dock, output_scaffold_only )
 	OPT_1GRP_KEY(  Boolean     , rif_dock, output_full_scaffold_only )
 	OPT_1GRP_KEY(  Boolean     , rif_dock, output_full_scaffold )
+    OPT_1GRP_KEY(  Boolean     , rif_dock, outputlite )
 	OPT_1GRP_KEY(  Boolean     , rif_dock, outputsilent )
 	OPT_1GRP_KEY(  Integer     , rif_dock, n_pdb_out )
     OPT_1GRP_KEY(  Integer     , rif_dock, n_pdb_out_global )
@@ -327,6 +328,7 @@ OPT_1GRP_KEY(     StringVector , rif_dock, scaffolds )
 			NEW_OPT(  rif_dock::output_scaffold_only, "" , false );
 			NEW_OPT(  rif_dock::output_full_scaffold_only, "" , false );
 			NEW_OPT(  rif_dock::output_full_scaffold, "", false );
+            NEW_OPT(  rif_dock::outputlite, "Write the output structures as compressed silent files", false );
 			NEW_OPT(  rif_dock::outputsilent, "", false );
 			NEW_OPT(  rif_dock::n_pdb_out, "" , 10 );
             NEW_OPT(  rif_dock::n_pdb_out_global, "Normally n_pdb_out applies to each seeding position, this caps the global", -1);
@@ -630,6 +632,7 @@ struct RifDockOpt
 	bool        output_scaffold_only                 ;
 	bool        output_full_scaffold_only            ;
 	bool        output_full_scaffold                 ;
+    bool        outputlite                           ;
 	bool        outputsilent                         ;
 	bool        pdb_info_pikaa                       ;
     bool        pdb_info_pssm                        ;
@@ -887,6 +890,7 @@ struct RifDockOpt
 		output_scaffold_only                   = option[rif_dock::output_scaffold_only                  ]();
 		output_full_scaffold_only              = option[rif_dock::output_full_scaffold_only             ]();
 		output_full_scaffold                   = option[rif_dock::output_full_scaffold                  ]();
+        outputlite                             = option[rif_dock::outputlite                            ]();
 		outputsilent                           = option[rif_dock::outputsilent                          ]();
 		pdb_info_pikaa                         = option[rif_dock::pdb_info_pikaa                        ]();
         pdb_info_pssm                          = option[rif_dock::pdb_info_pssm                         ]();
@@ -1059,6 +1063,8 @@ struct RifDockOpt
 
 		runtime_assert_msg( min_hb_quality_for_satisfaction < 0 && min_hb_quality_for_satisfaction > -1, 
 			"-min_hb_quality_for_satisfaction must be between -1 and 0");
+
+        runtime_assert_msg( !( outputsilent && outputlite ), "-outputsilent and -outputlite cannot be chosen together");
 
         nfold_symmetry = option[rif_dock::nfold_symmetry]();
         symmetry_axis.clear();

--- a/apps/rosetta/riflib/rifdock_tasks/OutputResultsTasks.cc
+++ b/apps/rosetta/riflib/rifdock_tasks/OutputResultsTasks.cc
@@ -22,10 +22,13 @@
 #include <core/pose/PDBInfo.hh>
 #include <core/pose/util.hh>
 #include <core/pose/Pose.hh>
+#include <core/pose/annotated_sequence.hh>
 #include <core/io/silent/BinarySilentStruct.hh>
 #include <core/io/silent/SilentFileData.hh>
 #include <core/io/silent/SilentFileOptions.hh>
+#include <core/kinematics/RT.hh>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -87,7 +90,7 @@ OutputResultsTask::return_rif_dock_results(
     if( rdd.opt.align_to_scaffold ) std::cout << "ALIGN TO SCAFFOLD" << std::endl;
     else                        std::cout << "ALIGN TO TARGET"   << std::endl;
     utility::io::ozstream out_silent_stream;
-    if ( rdd.opt.outputsilent ) {
+    if ( rdd.opt.outputsilent || rdd.opt.outputlite ) {
         ScaffoldDataCacheOP example_data_cache = rdd.scaffold_provider->get_data_cache_slow( ScaffoldIndex() );
         out_silent_stream.open_append( rdd.opt.outdir + "/" + example_data_cache->scafftag + ".silent" );
     }
@@ -476,7 +479,7 @@ dump_rif_result_(
 
 
     // Dump the main output
-    if (!rdd.opt.outputsilent) {
+    if ( !rdd.opt.outputsilent && !rdd.opt.outputlite ) {
         utility::io::ozstream out1( pdboutfile );
         out1 << expdb.str() << std::endl;
         pose_to_dump.dump_pdb(out1);
@@ -522,6 +525,46 @@ dump_rif_result_(
         sfd._write_silent_struct(*ss, out_silent_stream);
     }
 
+    // Dump silent file of PDBLite structures
+    if ( rdd.opt.outputlite ) {
+
+        core::pose::Pose lite_pose;
+        core::pose::make_pose_from_sequence( lite_pose, "A", core::chemical::FA_STANDARD, false ); // Auto-termini set to false
+
+        core::pose::PDBInfoOP pdb_info = make_shared< core::pose::PDBInfo >();
+
+        pdb_info->resize_residue_records(1);
+        pdb_info->add_reslabel( 1, "SCAFFOLD_PDB:" + sdc->scaff_fname );
+        pdb_info->add_reslabel( 1, "TARGET_PDB:" + rdd.opt.target_pdb );
+
+        EigenXform binder_xform = EigenXform( xposition1 );
+        binder_xform.translate( -1 * sdc->scaffold_center );
+
+        std::ostringstream RT_binder_stream;
+        RT_binder_stream << core::kinematics::RT( eigen2xyz(binder_xform).R , eigen2xyz(binder_xform).t );
+
+        std::string RT_binder_str = "SCAFFOLD_XFORM:" + RT_binder_stream.str().substr( 3 ); // Remove initial RT from xform string
+
+        std::replace( RT_binder_str.begin(), RT_binder_str.end(), ' ', '_');
+
+        pdb_info->add_reslabel( 1, RT_binder_str );
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        // TODO: implement mutation field here - NRB
+        ////////////////////////////////////////////////////////////////////////////////////////////
+
+        // Final setting of pdb_info
+        lite_pose.pdb_info( pdb_info );
+
+        std::string model_tag = pdb_name(pdboutfile);
+        core::io::silent::SilentFileOptions sf_option;
+        sf_option.read_from_global_options();
+        core::io::silent::SilentFileData sfd("", false, false, "binary", sf_option);
+        core::io::silent::SilentStructOP ss = sfd.create_SilentStructOP();
+        ss->fill_struct( lite_pose, model_tag ); // only line changed from above, would be prettier to make this it's own func - NRB
+        sfd._write_silent_struct(*ss, out_silent_stream);
+
+    }
 
 }
 

--- a/apps/rosetta/riflib/rifdock_tasks/OutputResultsTasks.hh
+++ b/apps/rosetta/riflib/rifdock_tasks/OutputResultsTasks.hh
@@ -59,6 +59,12 @@ dump_rif_result_(
     std::vector<float> const & unsat_scores = std::vector<float>()
     );
 
+// You would think that it would be easier to get the absolute path but it's not
+// It's easy with C++17 but that requires gcc7 which I don't think works with rifdock
+// There is a boost::filesystem library but that is known to generate linker issues - NRB
+std::string
+absolute_path( std::string relative_path );
+
 void
 dump_search_point_(
     RifDockData & rdd,

--- a/apps/rosetta/riflib/scaffold/MorphingScaffoldProvider.cc
+++ b/apps/rosetta/riflib/scaffold/MorphingScaffoldProvider.cc
@@ -49,9 +49,10 @@ MorphingScaffoldProvider::MorphingScaffoldProvider(
     EigenXform scaffold_perturb;
     MorphRules morph_rules;
     ExtraScaffoldData extra_data;
+    std::string scaff_fname;
 
 
-    get_info_for_iscaff( iscaff, opt, scafftag, scaffold, scaffold_res, scaffold_perturb, morph_rules, extra_data, rot_index_p);
+    get_info_for_iscaff( iscaff, opt, scafftag, scaffold, scaffold_res, scaffold_perturb, morph_rules, extra_data, rot_index_p, scaff_fname);
 
     ScaffoldDataCacheOP temp_data_cache_ = make_shared<ScaffoldDataCache>(
         scaffold,
@@ -60,7 +61,8 @@ MorphingScaffoldProvider::MorphingScaffoldProvider(
         scaffold_perturb,
         rot_index_p,
         opt,
-        extra_data);
+        extra_data,
+	scaff_fname);
 
     ParametricSceneConformationCOP conformation = make_conformation_from_data_cache(temp_data_cache_, false);
 
@@ -89,9 +91,10 @@ MorphingScaffoldProvider::test_make_children(TreeIndex ti) {
     EigenXform scaffold_perturb;
     MorphRules morph_rules;
     ExtraScaffoldData extra_data;
+    std::string scaff_fname; 
 
 
-    get_info_for_iscaff( 0, opt, scafftag, _scaffold, scaffold_res, scaffold_perturb, morph_rules, extra_data, rot_index_p);
+    get_info_for_iscaff( 0, opt, scafftag, _scaffold, scaffold_res, scaffold_perturb, morph_rules, extra_data, rot_index_p, scaff_fname );
 
 
 
@@ -169,7 +172,8 @@ MorphingScaffoldProvider::test_make_children(TreeIndex ti) {
                     scaffold_perturb,
                     rot_index_p,
                     opt,
-                    extra_data
+                    extra_data,
+		    scaff_fname
                     );
 
 
@@ -256,7 +260,8 @@ MorphingScaffoldProvider::test_make_children(TreeIndex ti) {
                 scaffold_perturb,
                 rot_index_p,
                 opt,
-                extra_data
+                extra_data,
+		scaff_fname
                 );
 
 

--- a/apps/rosetta/riflib/scaffold/NineAManager.hh
+++ b/apps/rosetta/riflib/scaffold/NineAManager.hh
@@ -284,6 +284,8 @@ struct NineAManager : public utility::pointer::ReferenceCount {
         EigenXform scaffold_perturb = EigenXform::Identity();
         ExtraScaffoldData extra_data;
 
+        std::string scaff_fname; // Faking this data for now - NRB
+
         get_default_scaffold_res(*pose_p, scaffold_res);
 
         ScaffoldDataCacheOP temp_data_cache = make_shared<ScaffoldDataCache>(
@@ -293,7 +295,9 @@ struct NineAManager : public utility::pointer::ReferenceCount {
             scaffold_perturb,
             rot_index_p,
             opt,
-            extra_data);
+            extra_data,
+            scaff_fname
+	    );
 
         nine.conformation = make_conformation_from_data_cache(temp_data_cache, false);
 

--- a/apps/rosetta/riflib/scaffold/ScaffoldDataCache.hh
+++ b/apps/rosetta/riflib/scaffold/ScaffoldDataCache.hh
@@ -42,6 +42,7 @@ struct ScaffoldDataCache {
 
 // setup during constructor
     std::string scafftag;
+    std::string scaff_fname;
 
     shared_ptr<utility::vector1<core::Size>> scaffold_res_p;                   // Seqposs of residues to design, default whole scaffold
 
@@ -116,7 +117,8 @@ struct ScaffoldDataCache {
         EigenXform const & scaffold_perturb_in,
         shared_ptr< RotamerIndex > rot_index_p,
         RifDockOpt const & opt,
-        ExtraScaffoldData const & extra_data
+        ExtraScaffoldData const & extra_data,
+	    std::string const & scaffold_name
     ) {
 
         debug_sanity = 1337;
@@ -125,6 +127,8 @@ struct ScaffoldDataCache {
         scafftag = scafftag_in;
         scaff_res_hashstr = ::devel::scheme::get_res_list_hash( *scaffold_res_p );
         scaffold_perturb = scaffold_perturb_in;
+
+	    scaff_fname = scaffold_name;
 
         typedef numeric::xyzVector<core::Real> Vec;
 

--- a/apps/rosetta/riflib/scaffold/SingleFileScaffoldProvider.cc
+++ b/apps/rosetta/riflib/scaffold/SingleFileScaffoldProvider.cc
@@ -47,8 +47,9 @@ SingleFileScaffoldProvider::SingleFileScaffoldProvider(
     EigenXform scaffold_perturb;
     MorphRules morph_rules;
     ExtraScaffoldData extra_data;
+    std::string scaff_fname;
 
-    get_info_for_iscaff( iscaff, opt, scafftag, scaffold, scaffold_res, scaffold_perturb, morph_rules, extra_data, rot_index_p);
+    get_info_for_iscaff( iscaff, opt, scafftag, scaffold, scaffold_res, scaffold_perturb, morph_rules, extra_data, rot_index_p, scaff_fname);
 
     ScaffoldDataCacheOP temp_data_cache = make_shared<ScaffoldDataCache>(
         scaffold,
@@ -57,7 +58,8 @@ SingleFileScaffoldProvider::SingleFileScaffoldProvider(
         scaffold_perturb,
         rot_index_p,
         opt,
-        extra_data);
+        extra_data,
+	    scaff_fname);
 
     conformation_ = make_conformation_from_data_cache(temp_data_cache, false);
 

--- a/apps/rosetta/riflib/scaffold/util.cc
+++ b/apps/rosetta/riflib/scaffold/util.cc
@@ -67,10 +67,12 @@ get_info_for_iscaff(
     EigenXform & scaffold_perturb,
     MorphRules & morph_rules,
     ExtraScaffoldData & extra_data,
-    shared_ptr< RotamerIndex > rot_index_p
+    shared_ptr< RotamerIndex > rot_index_p,
+    std::string & scaffold_filename
     ) {
 
     std::string scaff_fname = opt.scaffold_fnames.at(iscaff);
+    scaffold_filename = scaff_fname; // NRB
     scafftag = pdb_name(scaff_fname);
 
     std::cout << "!!!!!!!!!!!!!!!name:: " << scaff_fname << std::endl;

--- a/apps/rosetta/riflib/scaffold/util.hh
+++ b/apps/rosetta/riflib/scaffold/util.hh
@@ -50,7 +50,8 @@ get_info_for_iscaff(
     EigenXform & scaffold_perturb,
     MorphRules & morph_rules,
     ExtraScaffoldData & extra_data,
-    shared_ptr< RotamerIndex > rot_index_p_in
+    shared_ptr< RotamerIndex > rot_index_p_in,
+    std::string & scaffold_filename
     );
 
 // historically, non_fa was used during HSearch and fa was used during hack pack


### PR DESCRIPTION
Edits made. Versions of C++ less than 17 do not have std::filesystem so there is no easy way to do absolute path. The boost::filesystem library has an absolute path function but it is know to have linker issues and StackOverflow says that these are very difficult to get around. So I just wrote a quick function that does absolute path on its own.