### PR TITLE
Fix for arm64 Macs

### DIFF
--- a/schemelib/scheme/chemical/RotamerIndex.hh
+++ b/schemelib/scheme/chemical/RotamerIndex.hh
@@ -749,7 +749,7 @@ struct RotamerIndex {
 		sanity_check();
 	}
 
-	bool
+	void
 	sanity_check() const
 	{
 		using std::cerr;


### PR DESCRIPTION
Brian, Longxing- I've found that the function RotamerIndex::sanity_check() causes seg faults on arm64 M1 Macs.  It seems like a simple fix is just to change the return value of the function from bool to void.  sanity_check() is only called in build_index() (directly above it) and the return value is not checked so this shouldn't change any results.  Not sure why this matters (i.e., why the function can't just return without a return value), but I would bet it's something specific to the unofficial GCC-11 version I'm using for this architecture.