### PR TITLE
replacing libxml2 with xml2 in CMakeLists.txt

### DIFF
--- a/apps/rosetta/CMakeLists.txt
+++ b/apps/rosetta/CMakeLists.txt
@@ -11,7 +11,7 @@ set( ROSETTA_SRC $ENV{CMAKE_ROSETTA_PATH}/source )
 link_directories( ${ROSETTA_BIN} )
 
 set( ALL_ROSETTA_LIBS
-basic cifparse core.1 core.2 core.3 core.4 core.5 cppdb devel libxml2 numeric ObjexxFCL protocols.1 protocols.3 protocols.4 protocols.7 protocols.8 protocols_a.2 protocols_a.5 protocols_a.6 protocols_b.2 protocols_b.5 protocols_b.6 protocols_c.5 protocols_c.6 protocols_d.5 protocols_d.6 protocols_e.5 protocols_e.6 protocols_f.5 protocols_g.5 protocols_h.5 sqlite3 utility
+basic cifparse core.1 core.2 core.3 core.4 core.5 cppdb devel xml2 numeric ObjexxFCL protocols.1 protocols.3 protocols.4 protocols.7 protocols.8 protocols_a.2 protocols_a.5 protocols_a.6 protocols_b.2 protocols_b.5 protocols_b.6 protocols_c.5 protocols_c.6 protocols_d.5 protocols_d.6 protocols_e.5 protocols_e.6 protocols_f.5 protocols_g.5 protocols_h.5 sqlite3 utility
  
 #	basic core.1 core.2 core.3 core.4 core.5 devel numeric ObjexxFCL protocols.1 protocols.3 protocols.6 protocols.7 
 #	protocols_a.2 protocols_a.4 protocols_a.5 protocols_b.2 protocols_b.4 protocols_b.5 protocols_c.4 protocols_c.5 

--- a/schemelib/test/CMakeLists.txt
+++ b/schemelib/test/CMakeLists.txt
@@ -3,7 +3,7 @@ set( ROSETTA_SRC $ENV{CMAKE_ROSETTA_PATH}/source )
 link_directories( ${ROSETTA_BIN} )
 
 set( ALL_ROSETTA_LIBS
-basic cifparse core.1 core.2 core.3 core.4 core.5 cppdb devel libxml2 numeric ObjexxFCL protocols.1 protocols.3 protocols.4 protocols.7 protocols.8 protocols_a.2 protocols_a.5 protocols_a.6 protocols_b.2 protocols_b.5 protocols_b.6 protocols_c.5 protocols_c.6 protocols_d.5 protocols_d.6 protocols_e.5 protocols_e.6 protocols_f.5 protocols_g.5 protocols_h.5 sqlite3 utility
+basic cifparse core.1 core.2 core.3 core.4 core.5 cppdb devel xml2 numeric ObjexxFCL protocols.1 protocols.3 protocols.4 protocols.7 protocols.8 protocols_a.2 protocols_a.5 protocols_a.6 protocols_b.2 protocols_b.5 protocols_b.6 protocols_c.5 protocols_c.6 protocols_d.5 protocols_d.6 protocols_e.5 protocols_e.6 protocols_f.5 protocols_g.5 protocols_h.5 sqlite3 utility
  
 #   basic core.1 core.2 core.3 core.4 core.5 devel numeric ObjexxFCL protocols.1 protocols.3 protocols.6 protocols.7 
 #   protocols_a.2 protocols_a.4 protocols_a.5 protocols_b.2 protocols_b.4 protocols_b.5 protocols_c.4 protocols_c.5 


### PR DESCRIPTION
Building on linux got an error about missing -llibxml2. Linker strips the "lib" from the library name so changing "libxml2" to "xml2" which results in a correct build, as the library is called libxml2.so. 